### PR TITLE
Google tracking

### DIFF
--- a/src/constants/tracking-code-snippet.js
+++ b/src/constants/tracking-code-snippet.js
@@ -1,13 +1,17 @@
 const TRACKING_ID = require('../secrets').googleTrackingId;
 
-const trackingCodeSnippet = `
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+let trackingCodeSnippet = '';
 
-  ga('create', '${TRACKING_ID}', 'auto');
-  ga('send', 'pageview');
-`;
+if (TRACKING_ID) {
+  trackingCodeSnippet = `
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  
+    ga('create', '${TRACKING_ID}', 'auto');
+    ga('send', 'pageview');
+  `;
+}
 
 export default trackingCodeSnippet;

--- a/src/server/views/about.jsx
+++ b/src/server/views/about.jsx
@@ -30,8 +30,8 @@ export default class About extends React.Component {
           <meta property='og:image:width' content='480'/>
           <meta property='og:image:height' content='248'/>
 
-          {require('../../secrets').googleTrackingId &&
-          <script dangerouslySetInnerHTML={{ __html: trackingCodeSnippet }}/>
+          {trackingCodeSnippet &&
+            <script dangerouslySetInnerHTML={{ __html: trackingCodeSnippet }}/>
           }
         </head>
 

--- a/src/server/views/app.jsx
+++ b/src/server/views/app.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import config from '../../config/variables';
 import getWebpackAssets from '../../tools/get-webpack-assets';
-import trackingCodeSnippet from '../../constants/tracking-code-snippet';
 
 
 export default class App extends React.Component {
@@ -20,9 +19,7 @@ export default class App extends React.Component {
           <script src={getWebpackAssets().runtime.js} />
           <script src={getWebpackAssets().vendors.js} />
           <script src={getWebpackAssets().app.js} />
-          {require('../../secrets').googleTrackingId &&
-          <script dangerouslySetInnerHTML={{ __html: trackingCodeSnippet }}/>
-          }
+
           <link rel='stylesheet' type='text/css' href={getWebpackAssets().app.css}/>
 
           <link rel='icon' type='image/png' sizes='32x32' href='/static/icons/koifly-icon-32x32-round.png'/>


### PR DESCRIPTION
More Google tracking changes started in #4:

- Tracking is only enabled on home page
- Tracking script is generated only if there is a tracking id