### PR TITLE
IGC GPS altitude indexes

### DIFF
--- a/src/secrets-sample.js
+++ b/src/secrets-sample.js
@@ -41,7 +41,7 @@ const secrets = {
   googleMapsApiKey: 'key',
 
   // your google analytics tracking id
-  googleTrackingId: 'UI-*******-**', // empty string to disable tracking script 
+  googleTrackingId: 'UI-*******-**', // empty string to disable tracking script
 
   // SSL assets
   shouldUseSSL: false, // true for production server with SSL certificate

--- a/src/services/igc-service.js
+++ b/src/services/igc-service.js
@@ -103,7 +103,6 @@ const igcService = {
   findFlightDate(records, timeInSec, lng) {
     let dateRecord;
     for (let i = 0; i < records.length; i++) {
-
       const record = records[i];
       const isHeaderRecord = (record[0] === 'H') || (record[0] === 'A');
       if (!isHeaderRecord) {
@@ -111,7 +110,7 @@ const igcService = {
         break;
       }
       if (record.substring(2, 5) === 'DTE') {
-        if(record.substring(5, 9) === 'DATE') {
+        if (record.substring(5, 9) === 'DATE') {
           // new spec long format (v2)
           dateRecord = record.substring(10, 16);
         } else {

--- a/src/services/igc-service.js
+++ b/src/services/igc-service.js
@@ -161,13 +161,13 @@ const igcService = {
 
   /**
    * Searches for E record (Event record) which signifies that flight began and all followed records belong to
-   * the flight. E record should include STA (Start) or ATS (Activity Tracking System) mnemonic.
+   * the flight. E record should include STA (Start) mnemonic.
    * @param {Array} records – List of igc file lines.
    * @return {number} – Returns start index, or -1 if igc doesn't have start event in its records.
    */
   findStartIndex(records) {
     return records.findIndex(record => {
-      return record.startsWith('E') && (record.includes('STA') || record.includes('ATS'));
+      return record.startsWith('E') && record.includes('STA');
     });
   },
 


### PR DESCRIPTION
Now we fall to GPS altitude if barometer altitude is missing. IGC spec v1 doesn't require GPS altitude to show in a specific place in `B` record. For backward compatibility I'm checking GPS altitude indexes in `I` record before assuming that IGC file follows new standard and have that altitude recorded at `[30, 34]` position.

