### PR TITLE
Added public url config variable

### DIFF
--- a/src/config/variables.js
+++ b/src/config/variables.js
@@ -20,6 +20,7 @@ const SERVER_BARE_HOST = secrets.bareDomain;
 const SERVER_PROTOCOL = secrets.protocol;
 const SERVER_HTTPS_PORT = secrets.port.https;
 const SERVER_HTTP_PORT = secrets.port.http;
+const PUBLIC_ROOT_URL = secrets.publicRootUrl;
 
 const DEV_SERVER_HOST = '0.0.0.0';
 const DEV_SERVER_PROTOCOL = 'http';
@@ -84,7 +85,7 @@ if (process.env.NODE_ENV === 'development') {
     httpsPort: SERVER_HTTPS_PORT,
     httpPort: SERVER_HTTP_PORT,
     protocol: SERVER_PROTOCOL,
-    rootUrl: SERVER_PROTOCOL + '://' + SERVER_HOST
+    rootUrl: PUBLIC_ROOT_URL || SERVER_PROTOCOL + '://' + SERVER_HOST
   });
   Object.assign(config.webpack, {
     // Webpack bundle filename

--- a/src/secrets-sample.js
+++ b/src/secrets-sample.js
@@ -9,6 +9,9 @@ const secrets = {
     https: 443,
     http: 80
   },
+  // set this parameter if your Node server is run behind another one, e.g. nginx,
+  // this public root url will be used to in emails as link to your application
+  publicRootUrl: 'http://example.com',
 
   // your DB config
   // Admin user is used for initial tables creation (has CREATE, ALTER, DROP privileges)


### PR DESCRIPTION
In case you are running Node server on localhost behind Nginx or other server that control access to ports and provides SSL, now you can configure Node server host and ports separate from public facing urls.