### PR TITLE
Cookie setting for Nginx

### DIFF
--- a/src/components/public-views/reset-password.jsx
+++ b/src/components/public-views/reset-password.jsx
@@ -9,7 +9,7 @@ import errorTypes from '../../errors/error-types';
 import KoiflyError from '../../errors/error';
 import MobileButton from '../common/buttons/mobile-button';
 import MobileTopMenu from '../common/menu/mobile-top-menu';
-import NavigationMenu from "../common/menu/navigation-menu";
+import NavigationMenu from '../common/menu/navigation-menu';
 import navigationService from '../../services/navigation-service';
 import Notice from '../common/notice/notice';
 import PasswordInput from '../common/inputs/password-input';

--- a/src/server.js
+++ b/src/server.js
@@ -77,8 +77,7 @@ async function start() {
       name: 'koifly',
       password: secrets.cookiePassword,
       ttl: secrets.cookieLifeTime,
-      // domain: null - the domain that cookie was created
-      domain: process.env.NODE_ENV === 'development' ? null : config.server.host,
+      // no domain - browser will use the domain that cookie was created on
       path: '/',
       clearInvalid: true,
       isSecure: false, // cookie allows to be transmitted over insecure connection
@@ -93,8 +92,7 @@ async function start() {
   // Register csrf cookie
   server.state('csrf', {
     ttl: secrets.cookieLifeTime,
-    // domain: null - the domain that cookie was created
-    domain: process.env.NODE_ENV === 'development' ? null : config.server.host,
+    // no domain - browser will use the domain that cookie was created on
     path: '/',
     isSecure: false, // cookie allows to be transmitted over insecure connection
     isHttpOnly: false, // scrf cookie is available to js


### PR DESCRIPTION
Set cookie on the domain the request came from rather than the domain the Node server is running on. For cases when Node server is run behind Nginx or a different server